### PR TITLE
feat: add release workflow for multi-platform binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,135 @@
+name: Release binaries
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [created, published]
+
+permissions:
+  contents: write
+
+jobs:
+  prepare_release:
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.set_upload_url.outputs.upload_url }}
+      tag_name: ${{ steps.tag.outputs.tag_name }}
+    steps:
+      - name: Determine tag name
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "tag_name=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag_name=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create release when tag is pushed
+        id: create_release
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.tag_name }}
+          release_name: ${{ steps.tag.outputs.tag_name }}
+          draft: false
+          prerelease: false
+      - name: Resolve release upload URL
+        id: set_upload_url
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "upload_url=${{ github.event.release.upload_url }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "upload_url=${{ steps.create_release.outputs.upload_url }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    runs-on: ubuntu-latest
+    needs: prepare_release
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            ext: ''
+            archive: tar.gz
+            content_type: application/gzip
+          - goos: linux
+            goarch: arm64
+            ext: ''
+            archive: tar.gz
+            content_type: application/gzip
+          - goos: darwin
+            goarch: amd64
+            ext: ''
+            archive: tar.gz
+            content_type: application/gzip
+          - goos: darwin
+            goarch: arm64
+            ext: ''
+            archive: tar.gz
+            content_type: application/gzip
+          - goos: windows
+            goarch: amd64
+            ext: '.exe'
+            archive: zip
+            content_type: application/zip
+          - goos: windows
+            goarch: arm64
+            ext: '.exe'
+            archive: zip
+            content_type: application/zip
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build ${{ matrix.goos }}-${{ matrix.goarch }} binary
+        run: |
+          mkdir -p dist
+          output="dist/devlink-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}"
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 \
+            go build -o "$output" ./cmd/devlink
+      - name: Package archive
+        run: |
+          set -euo pipefail
+          binary_name="devlink${{ matrix.ext }}"
+          archive_basename="devlink-${{ needs.prepare_release.outputs.tag_name }}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          build_artifact="dist/devlink-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}"
+          stage_dir="dist/${archive_basename}"
+
+          mkdir -p "$stage_dir"
+          cp "$build_artifact" "$stage_dir/$binary_name"
+          cp LICENSE "$stage_dir/"
+
+          if [ "${{ matrix.archive }}" = "zip" ]; then
+            (cd "$stage_dir" && zip -r "../${archive_basename}.zip" .)
+            rm -rf "$stage_dir"
+            (cd dist && sha256sum "${archive_basename}.zip" > "${archive_basename}.zip.sha256")
+          else
+            (cd "$stage_dir" && tar -czf "../${archive_basename}.tar.gz" .)
+            rm -rf "$stage_dir"
+            (cd dist && sha256sum "${archive_basename}.tar.gz" > "${archive_basename}.tar.gz.sha256")
+          fi
+      - name: Upload packaged archive
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
+          asset_path: dist/devlink-${{ needs.prepare_release.outputs.tag_name }}-${{ matrix.goos }}-${{ matrix.goarch }}.${{ matrix.archive }}
+          asset_name: devlink-${{ needs.prepare_release.outputs.tag_name }}-${{ matrix.goos }}-${{ matrix.goarch }}.${{ matrix.archive }}
+          asset_content_type: ${{ matrix.content_type }}
+      - name: Upload checksum file
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
+          asset_path: dist/devlink-${{ needs.prepare_release.outputs.tag_name }}-${{ matrix.goos }}-${{ matrix.goarch }}.${{ matrix.archive }}.sha256
+          asset_name: devlink-${{ needs.prepare_release.outputs.tag_name }}-${{ matrix.goos }}-${{ matrix.goarch }}.${{ matrix.archive }}.sha256
+          asset_content_type: text/plain

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Devlink은 로컬 개발 환경에서 `*.localhost` 도메인을 대상으로 �
 - `fsnotify`를 사용해 구성 파일 변경을 감지하고 실시간으로 라우트를 갱신합니다.
 
 ### 설치
+1. GitHub Releases 페이지에서 운영체제에 맞는 압축 파일을 내려받습니다. 릴리스에는 각 파일의 무결성을 확인할 수 있는 `.sha256` 체크섬이 함께 올라갑니다. Linux에서는 `sha256sum -c <파일명>.sha256`, macOS에서는 `shasum -a 256 -c <파일명>.sha256`으로 검증하고, Windows PowerShell에서는 `Get-FileHash .\<파일명>.zip -Algorithm SHA256` 출력이 `.sha256` 파일에 기록된 해시와 일치해야 합니다. 압축을 해제한 뒤 생성된 `devlink` 바이너리를 `$PATH` 어딘가에 배치하면 됩니다.
+
+2. 소스에서 직접 빌드하려면 다음 명령을 실행합니다.
 ```bash
 # 바이너리 빌드
 make build  # 또는 go build ./cmd/devlink
@@ -92,6 +95,9 @@ Devlink is a zero-config HTTPS gateway for local development that delivers produ
 - Live reload of configuration through `fsnotify`.
 
 ### Installation
+1. Download the archive that matches your operating system from the GitHub Releases page. Each release ships with companion `.sha256` checksum files. On Linux run `sha256sum -c <filename>.sha256`, on macOS run `shasum -a 256 -c <filename>.sha256`, and in Windows PowerShell verify that `Get-FileHash .\<filename>.zip -Algorithm SHA256` matches the hash stored in the checksum file. After extracting the archive, place the `devlink` binary somewhere on your `$PATH`.
+
+2. To build from source instead, run the following:
 ```bash
 # Build the binary
 make build  # or go build ./cmd/devlink


### PR DESCRIPTION
## Summary
- add a release workflow that cross-compiles devlink for Linux, macOS, and Windows targets and uploads the archives to the matching GitHub release
- automatically publish checksum files alongside each packaged artifact
- document release downloads and checksum verification steps in both Korean and English installation guides

## Testing
- go test ./... -run Test -count=1 -timeout 60s

------
https://chatgpt.com/codex/tasks/task_e_68d54b69ff9883278f7b1dd23ff3c1a3